### PR TITLE
Add GCDWebserver from POD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = dev
 [submodule "core"]
 	path = core
-	url = https://github.com/ConnectSDK/Connect-SDK-iOS-Core.git
+	url = https://github.com/sergiou87/Connect-SDK-iOS-Core.git
 	branch = dev

--- a/ConnectSDK.podspec
+++ b/ConnectSDK.podspec
@@ -81,8 +81,8 @@ Pod::Spec.new do |s|
     sp.dependency 'ConnectSDK/Core'
     sp.source_files = "modules/**/*.{h,m}"
     sp.private_header_files = "modules/**/*_Private.h"
-    
-    cast_version = "2.5.1"
+
+    cast_version = "2.5.2"
     sp.dependency "google-cast-sdk", cast_version
     sp.framework = "GoogleCast"
     sp.xcconfig = {

--- a/ConnectSDK.podspec
+++ b/ConnectSDK.podspec
@@ -69,6 +69,7 @@ Pod::Spec.new do |s|
     sp.requires_arc = true
 
     sp.dependency 'ConnectSDK/no-arc'
+    sp.dependency 'GCDWebServer', '~> 3.2'
   end
 
   s.subspec 'no-arc' do |sp|


### PR DESCRIPTION
as GCDwebserver was moved from being statically embedded in core project we incloude it here from a pod.

There are a couple of extra commits in here to repoint the core submodule which need to be ignored at this time and the SDK bump should be seperated out.
